### PR TITLE
Fix header navigation bar and playwright test

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -82,7 +82,7 @@ githubEditUrl = "https://github.com/kartoza/hugo-bulma-blocks-theme/edit/main"
 corner-radius = "0px"
 
 ## Url to navigation web component
-uniNavHeaderUrl = 'https://konturio.github.io/qgis-uni-navigation/index.js'
+uniNavHeaderUrl = 'https://qgis.github.io/qgis-uni-navigation/index.js'
 uniNavHeaderLocationPrefix = "/QGIS-Hugo"
 
 ## Url to news feed. After URL change you have to check 

--- a/playwright/ci-test/tests/01-home-page.spec.ts
+++ b/playwright/ci-test/tests/01-home-page.spec.ts
@@ -21,7 +21,7 @@ const test = base.extend<HomePageFixtures>({
     footer: async ({ page }, use) => {
         const footer = new Footer(page);
         await use(footer);
-    }
+    },
 });
 
 test.describe("Home page", () => {
@@ -32,8 +32,8 @@ test.describe("Home page", () => {
 
     test("Header", async ({ header }) => {
         await expect(header.logoLink).toBeVisible();
-        await expect(header.productLink).toBeVisible();
-        await header.productLink.hover();
+        await expect(header.projectLink).toBeVisible();
+        await header.projectLink.hover();
         await expect(header.overviewLink).toBeVisible();
         await expect(header.caseStudiesLink).toBeVisible();
         await expect(header.pluginsLink).toBeVisible();

--- a/playwright/ci-test/tests/02-download-page.spec.ts
+++ b/playwright/ci-test/tests/02-download-page.spec.ts
@@ -33,7 +33,7 @@ test("Download page", async ({ homePage, sidebar, downloadPage }) => {
     await expect(downloadPage.otherMethodsLink).toBeVisible();
     await expect(downloadPage.currencyInput).toBeVisible();
     await expect(downloadPage.skipDownloadButton).toBeVisible();
-    await expect(sidebar.productLink).toBeVisible();
+    await expect(sidebar.projectLink).toBeVisible();
     await expect(sidebar.overviewLink).toBeVisible();
     await expect(sidebar.caseStudiesLink).toBeVisible();
     await expect(sidebar.pluginsLink).toBeVisible();

--- a/playwright/ci-test/tests/03-product-page.spec.ts
+++ b/playwright/ci-test/tests/03-product-page.spec.ts
@@ -27,7 +27,7 @@ const test = base.extend<ProductPageFixtures>({
 test("Product page", async ({ homePage, sidebar, productPage }) => {
     await homePage.goto();
     await homePage.downloadLink.click();
-    await sidebar.productLink.click();
+    await sidebar.projectLink.click();
     await expect(productPage.fosQGISLink).toBeVisible();
     await expect(productPage.qgisOverview).toBeVisible();
     await expect(productPage.contentTab1Img).toBeVisible();

--- a/playwright/ci-test/tests/fixtures/header.ts
+++ b/playwright/ci-test/tests/fixtures/header.ts
@@ -33,7 +33,9 @@ export class Header {
         this.banner = this.page.getByRole("banner");
         this.mainNavigation = this.page.getByLabel("main navigation");
         this.logoLink = this.mainNavigation.getByRole("link").first();
-        this.projectLink = this.mainNavigation.getByText("Project");
+        this.projectLink = this.mainNavigation.getByText("Project", {
+            exact: true,
+        });
         this.overviewLink = this.mainNavigation.getByRole("link", {
             name: "Overview",
         });

--- a/playwright/ci-test/tests/fixtures/header.ts
+++ b/playwright/ci-test/tests/fixtures/header.ts
@@ -4,7 +4,7 @@ export class Header {
     public readonly banner: Locator;
     public readonly mainNavigation: Locator;
     public readonly logoLink: Locator;
-    public readonly productLink: Locator;
+    public readonly projectLink: Locator;
     public readonly overviewLink: Locator;
     public readonly caseStudiesLink: Locator;
     public readonly pluginsLink: Locator;
@@ -33,7 +33,7 @@ export class Header {
         this.banner = this.page.getByRole("banner");
         this.mainNavigation = this.page.getByLabel("main navigation");
         this.logoLink = this.mainNavigation.getByRole("link").first();
-        this.productLink = this.mainNavigation.getByText("Product");
+        this.projectLink = this.mainNavigation.getByText("Project");
         this.overviewLink = this.mainNavigation.getByRole("link", {
             name: "Overview",
         });

--- a/playwright/ci-test/tests/fixtures/sidebar.ts
+++ b/playwright/ci-test/tests/fixtures/sidebar.ts
@@ -31,7 +31,7 @@ export class Sidebar {
     constructor(public readonly page: Page) {
         this.sidebar = this.page.locator("#sidebar");
         this.projectLink = this.sidebar.getByRole("link", {
-            name: "Project",
+            name: "Product",
         });
         this.overviewLink = this.sidebar.getByRole("link", {
             name: "Overview",

--- a/playwright/ci-test/tests/fixtures/sidebar.ts
+++ b/playwright/ci-test/tests/fixtures/sidebar.ts
@@ -2,7 +2,7 @@ import type { Page, Locator } from "@playwright/test";
 
 export class Sidebar {
     public readonly sidebar: Locator;
-    public readonly productLink: Locator;
+    public readonly projectLink: Locator;
     public readonly overviewLink: Locator;
     public readonly caseStudiesLink: Locator;
     public readonly pluginsLink: Locator;
@@ -30,8 +30,8 @@ export class Sidebar {
 
     constructor(public readonly page: Page) {
         this.sidebar = this.page.locator("#sidebar");
-        this.productLink = this.sidebar.getByRole("link", {
-            name: "Product",
+        this.projectLink = this.sidebar.getByRole("link", {
+            name: "Project",
         });
         this.overviewLink = this.sidebar.getByRole("link", {
             name: "Overview",


### PR DESCRIPTION
This is a proposed fix for the header navigation bar and the playwright e2e test workflow. I've also changed `Product` to `Project` in the test fixture for the header as they have been changed in the header navigation bar.

A preview of the header is available at: https://qgis.github.io/qgis-uni-navigation/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the URL for the navigation web component.
- **Tests**
	- Modified test scripts to align with updated link references in the app's header and sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->