### PR TITLE
Replace twitter with Mastodon

### DIFF
--- a/content/community/organisation/infrastructure.md
+++ b/content/community/organisation/infrastructure.md
@@ -67,10 +67,10 @@ Flickr Groups
 **Groupstarters:** Nathan W, Anita G, Matieu
 
 
-Twitter
+Mastodon
 -------------------------------------------
 
-{{< rich-list listLink="https://twitter.com/qgis"  layoutClass="half" listTitle="Twitter" listSubtitle="https://twitter.com/qgis" >}}
+{{< rich-list listLink="https://fosstodon.org/@qgis"  layoutClass="half" listTitle="Mastodon" listSubtitle="https://fosstodon.org/@qgis" >}}
 
 **Responsible:** Nathan W, Anita G
     

--- a/playwright/ci-test/tests/01-home-page.spec.ts
+++ b/playwright/ci-test/tests/01-home-page.spec.ts
@@ -130,7 +130,6 @@ test.describe("Home page", () => {
         await expect(footer.goodiesLink).toBeVisible();
         await expect(footer.logoImage).toBeVisible();
         await expect(footer.facebookLink).toBeVisible();
-        await expect(footer.twitterLink).toBeVisible();
         await expect(footer.youtubeLink).toBeVisible();
         await expect(footer.mapstodonLink).toBeVisible();
         await expect(footer.ghLink).toBeVisible();

--- a/playwright/ci-test/tests/fixtures/footer.ts
+++ b/playwright/ci-test/tests/fixtures/footer.ts
@@ -37,7 +37,6 @@ export class Footer {
     public readonly goodiesLink: Locator;
     public readonly logoImage: Locator;
     public readonly facebookLink: Locator;
-    public readonly twitterLink: Locator;
     public readonly youtubeLink: Locator;
     public readonly mapstodonLink: Locator;
     public readonly ghLink: Locator;
@@ -118,7 +117,6 @@ export class Footer {
         this.goodiesLink = this.page.getByRole("link", { name: "Goodies" });
         this.logoImage = this.page.getByRole("img", { name: "Logo" });
         this.facebookLink = this.page.getByRole("link", { name: "" });
-        this.twitterLink = this.page.getByRole("link", { name: "" });
         this.youtubeLink = this.page.getByRole("link", { name: "" });
         this.mapstodonLink = this.page
             .locator("div:nth-child(2) > div:nth-child(2) > a:nth-child(4)")

--- a/themes/hugo-bulma-blocks-theme/layouts/partials/footer.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/partials/footer.html
@@ -98,13 +98,10 @@
                 <a class="has-text-white" href="https://www.facebook.com/profile.php?id=100057434859831">
                     <i class="fa-brands fa-square-facebook"></i>
                 </a>
-                <a class="has-text-white" href="https://twitter.com/qgis">
-                    <i class="fa-brands fa-square-twitter"></i>
-                </a>
                 <a class="has-text-white" href="https://www.youtube.com/@qgishome">
                     <i class="fa-brands fa-youtube"></i>
                 </a>
-                <a class="has-text-white" href="https://mapstodon.space/@qgis@fosstodon.org">
+                <a class="has-text-white" href="https://fosstodon.org/@qgis">
                     <i class="fa-brands fa-foss"></i>
                 </a>
                 <a class="has-text-white" href="https://github.com/qgis/">


### PR DESCRIPTION
This is for #234

## Change summary

- Replace Twitter with Mastodon on the Infrastructure page
- Remove the Twitter link from the footer

![image](https://github.com/qgis/QGIS-Hugo/assets/43842786/6673de3a-a92c-40a8-8fea-766179b7f4ef)

![image](https://github.com/qgis/QGIS-Hugo/assets/43842786/3608909d-e615-4670-9aa6-874cf97eb69b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Switched community group communication from Twitter to Mastodon, updating relevant links and titles accordingly.

- **Documentation**
  - Updated community organization infrastructure documentation to reflect the new social media platform.

- **Style**
  - Updated footer links across the theme to point to the new Mastodon profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->