### PR TITLE
Update funders-simple.html, fixes #238

### DIFF
--- a/playwright/ci-test/tests/fixtures/home-page.ts
+++ b/playwright/ci-test/tests/fixtures/home-page.ts
@@ -118,7 +118,7 @@ export class HomePage {
             name: "View documentation",
         });
         this.qgisSupportersHeading = this.page.getByRole("heading", {
-            name: "QGIS supporters",
+            name: "QGIS sustaining members",
         });
         this.addYourLogoHereText = this.page
             .locator("div")
@@ -126,7 +126,7 @@ export class HomePage {
             .nth(2);
         this.silverPartnerText = this.page
             .locator("div")
-            .filter({ hasText: "Silver partner" })
+            .filter({ hasText: "Large membership" })
             .nth(2);
         this.supportersGridDiv = this.page
             .locator(".supporters-grid > div:nth-child(3)")

--- a/themes/hugo-bulma-blocks-theme/layouts/partials/funders-simple.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/partials/funders-simple.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="pb-2">
             <h2>
-                QGIS supporters
+                QGIS sustaining members
             </h2>
         </div>
         <div class="supporters-grid large-grid">
@@ -37,11 +37,11 @@
                             
                                 {{ if eq .Params.level "Flagship" }}
                                     <p class=" partner-title">
-                                        Golden partner
+                                        Flagship membership
                                     </p>
                                 {{ else }}
                                     <p class="partner-title">
-                                        Silver partner
+                                        Large membership
                                     </p>
                                 {{ end }}
                                 <br>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated terminology for QGIS supporters and partners:
    - "QGIS supporters" is now "QGIS sustaining members."
    - "Golden partner" is now "Flagship membership."
    - "Silver partner" is now "Large membership."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->