### PR TITLE
Update groups.md

### DIFF
--- a/content/community/groups.md
+++ b/content/community/groups.md
@@ -20,7 +20,7 @@ Reviewer: Tim Sutton
 
 {{< rich-list listLink="https://qgis.dk/" icon="🇩🇰  " layoutClass="half" listTitle="QGIS Brugergruppe Danmark (Denmark) " listSubtitle="Contact: Jacob Arpe" >}}
 
-{{< rich-list listLink="https://qgis.uk/" icon="🏴󠁧󠁢󠁥󠁮󠁧󠁿  " layoutClass="half" listTitle="QGIS UK (England) " listSubtitle="Contact: Simon Miles" >}}
+{{< rich-list listLink="https://uk.osgeo.org/qgis.html" icon="🏴󠁧󠁢󠁥󠁮󠁧󠁿  " layoutClass="half" listTitle="QGIS UK (England) " listSubtitle="Contact: Simon Miles" >}}
 
 {{< rich-list listLink="https://qgis.de/" icon="🇩🇪  " layoutClass="half" listTitle="QGIS Anwendergruppe Deutschland (Germany) " listSubtitle="Contact: Thomas Schüttenberg" >}}
 
@@ -34,11 +34,11 @@ Reviewer: Tim Sutton
 
 {{< rich-list listLink="https://qgis.pt/" icon="🇵🇹  " layoutClass="half" listTitle="QGIS Portugal " listSubtitle="Contact: João Gaspar" >}}
 
-{{< rich-list listLink="https://qgis.uk/" icon="🏴󠁧󠁢󠁳󠁣󠁴󠁿  " layoutClass="half" listTitle="QGIS UK (Scotland) " listSubtitle="Contact: Ross McDonald" >}}
+{{< rich-list listLink="https://uk.osgeo.org/qgis.html" icon="🏴󠁧󠁢󠁳󠁣󠁴󠁿  " layoutClass="half" listTitle="QGIS UK (Scotland) " listSubtitle="Contact: Ross McDonald" >}}
 
 {{< rich-list listLink="https://qgis.ch/" icon="🇨🇭  " layoutClass="half" listTitle="QGIS user group Switzerland " listSubtitle="Contact: Isabel Kiefer" >}}
 
-{{< rich-list listLink="http://qgis.uk/" icon="🏴󠁧󠁢󠁷󠁬󠁳󠁿  " layoutClass="half" listTitle="QGIS UK (Wales/Cymru) " listSubtitle="Contact: Kevin Williams" >}}
+{{< rich-list listLink="https://uk.osgeo.org/qgis.html" icon="🏴󠁧󠁢󠁷󠁬󠁳󠁿  " layoutClass="half" listTitle="QGIS UK (Wales/Cymru) " listSubtitle="Contact: Kevin Williams" >}}
 
 {{< rich-list listLink="https://teamwork.niwa.co.nz/display/NQUG/NIWA+QGIS+Users+Group" icon="🇳🇿  " layoutClass="half" listTitle="NIWA QGIS user group (New Zealand) " listSubtitle="Contact: Brent Wood –> REMOVED in 2018" >}}
 


### PR DESCRIPTION
Extending https://github.com/qgis/QGIS-Hugo/issues/219
See also https://github.com/qgis/QGIS-Website/pull/1257

I have updated links for QGIS User Group for the UK (England, Scotland and Wales). 

The previous URL http://qgis.uk is correct but for some reason wasn't working. It would show as: for me

"This site can’t be reached
qgis.uk refused to connect."

It's possibly because we have implemented a redirect to https://uk.osgeo.org/qgis.html, I am not sure. Typing qgis.uk in your browser works fine. 

Anyway, I am updating this in the hope the links will work on the new site. 

Feel free to correct/edit/commit as you see fit. 

Any questions, please let me know. 

https://github.com/qgis/QGIS-Hugo/issues/219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated QGIS UK group links for England, Scotland, and Wales/Cymru to `uk.osgeo.org/qgis.html` for improved accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->