### PR TITLE
Fix nixos python override notes

### DIFF
--- a/content/resources/installation-guide/index.md
+++ b/content/resources/installation-guide/index.md
@@ -407,19 +407,24 @@ nix-shell -p \
 **Or added to your NixOS configuration.nix so that it becomes part of your system install:**
 
 ```
-{ config, pkgs, ... }:
-
 {
+  config,
+  pkgs,
+  ...
+}: {
   environment.systemPackages = with pkgs; [
-    (qgis.overrideAttrs (old: {
-      buildInputs = old.buildInputs ++ [ 
-            pkgs.python3Packages.numpy 
-            pkgs.python3Packages.geopandas
-            pkgs.python3Packages.rasterio
-      ];
-    }))
+    (qgis.override {
+      extraPythonPackages = ps:
+        with ps; [
+          numpy
+          geopandas
+          rasterio
+        ];
+    })
+    # other packages
   ];
 }
+
 ```
 
 ## SUSE / openSUSE


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the installation guide to improve the package installation logic for NixOS configurations, specifically enhancing the inclusion of numpy, geopandas, and rasterio within the `qgis` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->