### PR TITLE
Extend config file for production and GH pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -50,8 +50,9 @@ jobs:
           HUGO_ENV: production
         run: |
           hugo \
-            --minify \
+            --config config.toml,config/config.gh-pages.toml \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Hugo default output directory
 /public
+/public_dev
+/public_www
+/public_nocache
+/public_prod
 /public_subsites
 /resources/_gen/
 .hugo_build.lock

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ help:
 	@echo
 	@echo "------------------------------------------------------------------"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort  | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m - %s\n", $$1, $$2}'
+
+# ----------------------------------------------------------------------------
+#    D O C K E R     C O M M A N D S
+# ----------------------------------------------------------------------------
  
 dev-build: ## Generate the development docker container
 	docker build --rm -f Dockerfile.dev -t qgis_hugo_dev:latest .
@@ -29,10 +33,45 @@ tests: ## Run the test suite
 	docker build --rm -f Dockerfile.tests -t qgis_hugo_tests:latest .
 	docker run --rm --net=host --volume "$${PWD}":/app -w /app qgis_hugo_tests:latest
 
-build: ## Build the site then run using python http.server
-	hugo --baseURL ""
-	python -m http.server 8000 -d public
-	#xdg-open http://localhost:8000
+
+# ----------------------------------------------------------------------------
+#    P R O D U C T I O N     C O M M A N D S
+# ----------------------------------------------------------------------------
+
+build: ## Build the site for nocache.qgis.org, www.qgis.org and qgis.org
+	@echo
+	@echo "------------------------------------------------------------------"
+	@echo "Building site in production"
+	@echo "------------------------------------------------------------------"
+	hugo --config config.toml,config/config.nocache.toml
+	hugo --config config.toml,config/config.prod.toml
+	hugo --config config.toml,config/config.www.toml
+
+
+# ----------------------------------------------------------------------------
+#    D E V E L O P M E N T     C O M M A N D S
+# ----------------------------------------------------------------------------
+
+hugo-dev-build: ## Build the site localy and run a python server at localhost:8000 with hugo
+	@echo
+	@echo "------------------------------------------------------------------"
+	@echo "Building site in development"
+	@echo "------------------------------------------------------------------"
+	hugo --config config.toml,config/config.dev.toml
+	python3 -m http.server 8000 -d public_dev
+
+
+hugo-run-dev: ## Run the server at localhost:1313 with hugo
+	@echo
+	@echo "------------------------------------------------------------------"
+	@echo "Building site in development"
+	@echo "------------------------------------------------------------------"
+	hugo server --config config.toml,config/config.dev.toml
+
+
+# ----------------------------------------------------------------------------
+#    U T I L S     C O M M A N D S
+# ----------------------------------------------------------------------------
 
 csv/schedule.csv scripts/schedule.ics data/conf.json:
 	python scripts/update-schedule.py

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-# May be overwritten in .github/workflows/github-pages.yml
+# May be overwritten in .github/workflows/github-pages.yml or other config files
 baseURL = 'https://qgis.org/'
 languageCode = 'en-us'
 title = 'QGIS Web Site'
@@ -82,7 +82,6 @@ corner-radius = "0px"
 
 ## Url to navigation web component
 uniNavHeaderUrl = 'https://qgis.github.io/qgis-uni-navigation/index.js'
-#uniNavHeaderLocationPrefix = "/QGIS-Hugo"
 uniNavHeaderLocationPrefix = ""
 
 ## Url to news feed. After URL change you have to check 

--- a/config/config.dev.toml
+++ b/config/config.dev.toml
@@ -1,0 +1,2 @@
+baseURL = 'http://localhost:8000/'
+publishDir = "public_dev"

--- a/config/config.gh-pages.toml
+++ b/config/config.gh-pages.toml
@@ -1,0 +1,4 @@
+minify = true
+
+[params]
+uniNavHeaderLocationPrefix = "/QGIS-Hugo"

--- a/config/config.nocache.toml
+++ b/config/config.nocache.toml
@@ -1,0 +1,3 @@
+baseURL = 'https://nocache.qgis.org/'
+publishDir = "public_nocache"
+minify = true

--- a/config/config.prod.toml
+++ b/config/config.prod.toml
@@ -1,0 +1,3 @@
+baseURL = 'https://qgis.org/'
+publishDir = "public_prod"
+minify = true

--- a/config/config.www.toml
+++ b/config/config.www.toml
@@ -1,0 +1,3 @@
+baseURL = 'https://www.qgis.org/'
+publishDir = "public_www"
+minify = true


### PR DESCRIPTION
This is a proposed solution for building the site for production and for the GH page.

- Specify the uniNavHeaderLocationPrefix for the GH page
- Build each subdomain's site in a different directory according to its config file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added .gitignore entries for development environments to streamline version control.
  - Introduced various configuration files (`config.dev.toml`, `config.gh-pages.toml`, `config.nocache.toml`, `config.prod.toml`, `config.www.toml`) for more flexible environment management.

- **Enhancements**
  - Updated `Makefile` with new commands for Docker, production, and development environments to facilitate easier builds and server management.
  - Enhanced `config.toml` to support dynamic configuration through other config files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->