### PR TITLE
Fix download URLs

### DIFF
--- a/content/download/index.md
+++ b/content/download/index.md
@@ -85,7 +85,7 @@ After installing QGIS, the first launch attempt may fail due to Apple's security
 {{< spoiler-start title="📃 Source Code" >}}
 QGIS is open source software available under the terms of the <b>GNU General Public License</b> meaning that its source code can be downloaded through 'tarballs' or the git repository.
 
-QGIS Source Code is available <a href="https://qgis.org/downloads/qgis-latest.tar.bz2">here (latest release)</a> and <a href="https://qgis.org/downloads/qgis-latest-ltr.tar.bz2">here (long term release)</a>
+QGIS Source Code is available <a href="https://download.qgis.org/downloads/qgis-latest.tar.bz2">here (latest release)</a> and <a href="https://download.qgis.org/downloads/qgis-latest-ltr.tar.bz2">here (long term release)</a>
 
 Refer to the installation guide on how to compile QGIS from source for the different platforms: [here](https://github.com/qgis/QGIS/blob/master/INSTALL.md)
 

--- a/content/resources/installation-guide/index.md
+++ b/content/resources/installation-guide/index.md
@@ -568,7 +568,7 @@ Official All-in-one, signed installers for macOS High Sierra (10.13) and newer c
 
 ## QGIS nightly release
 
-A nightly updated standalone installer from QGIS master can be downloaded from [here](https://qgis.org/downloads/macos/qgis-macos-nightly.dmg).
+A nightly updated standalone installer from QGIS master can be downloaded from [here](https://download.qgis.org/downloads/macos/qgis-macos-nightly.dmg).
 
 ## MacPorts
 
@@ -605,7 +605,7 @@ Concurrent installation of Homebrew and MacPorts is not compatible and will almo
 
 ## Old releases
 
-Previous releases of the official installer can be downloaded from https://qgis.org/downloads/macos/.
+Previous releases of the official installer can be downloaded from https://download.qgis.org/downloads/macos/.
 
 Previous releases of the kyngchaos installer can be downloaded from https://www.kyngchaos.com/software/archive/qgis/. The oldest installers support macOS 10.4 Tiger.
 

--- a/content/resources/releases.md
+++ b/content/resources/releases.md
@@ -14,8 +14,8 @@ Reviewer: Tim Sutton
 
 Previous releases of QGIS are available at the following locations:
 
-* [QGIS.org hosted downloads](https://qgis.org/downloads)
-* [Older releases for macOS / OS X](https://qgis.org/downloads/macOS/)
+* [QGIS.org hosted downloads](https://download.qgis.org/downloads)
+* [Older releases for macOS / OS X](https://download.qgis.org/downloads/macOS/)
 * [OSGeo hosted downloads](https://download.osgeo.org/qgis/) 
 * [Legacy 'Kyngchaos' macOS / OS X downloads](https://www.kyngchaos.com/software/archive/).
 

--- a/data/conf.json
+++ b/data/conf.json
@@ -23,9 +23,9 @@
     "userguidecite": "https://docs.qgis.org/3.34/en/docs/user_manual/index.html",
     "servercite": "https://docs.qgis.org/3.34/en/docs/server_manual/index.html",
     "apicite": "https://qgis.org/pyqgis/3.34/index.html",
-    "lr_msi": "https://qgis.org/downloads/QGIS-OSGeo4W-3.38.0-1.msi",
-    "lr_sha": "https://qgis.org/downloads/QGIS-OSGeo4W-3.38.0-1.sha256sum",
-    "ltr_msi": "https://qgis.org/downloads/QGIS-OSGeo4W-3.34.8-1.msi",
-    "ltr_sha": "https://qgis.org/downloads/QGIS-OSGeo4W-3.34.8-1.sha256sum",
+    "lr_msi": "https://download.qgis.org/downloads/QGIS-OSGeo4W-3.38.0-1.msi",
+    "lr_sha": "https://download.qgis.org/downloads/QGIS-OSGeo4W-3.38.0-1.sha256sum",
+    "ltr_msi": "https://download.qgis.org/downloads/QGIS-OSGeo4W-3.34.8-1.msi",
+    "ltr_sha": "https://download.qgis.org/downloads/QGIS-OSGeo4W-3.34.8-1.sha256sum",
     "weekly_msi": "https://download.osgeo.org/qgis/windows/weekly/?C=M&O=D"
 }

--- a/scripts/update-schedule.py
+++ b/scripts/update-schedule.py
@@ -254,10 +254,10 @@ with open("data/conf.json", "w") as f:
         "userguidecite": f"https://docs.qgis.org/{ltrversion}/en/docs/user_manual/index.html",
         "servercite": f"https://docs.qgis.org/{ltrversion}/en/docs/server_manual/index.html",
         "apicite": f"https://qgis.org/pyqgis/{ltrversion}/index.html",
-        "lr_msi": f"https://qgis.org/downloads/QGIS-OSGeo4W-{lr_version}-{lr_binary}.msi",
-        "lr_sha": f"https://qgis.org/downloads/QGIS-OSGeo4W-{lr_version}-{lr_binary}.sha256sum",
-        "ltr_msi": f"https://qgis.org/downloads/QGIS-OSGeo4W-{ltr_version}-{ltr_binary}.msi",
-        "ltr_sha": f"https://qgis.org/downloads/QGIS-OSGeo4W-{ltr_version}-{ltr_binary}.sha256sum",
+        "lr_msi": f"https://download.qgis.org/downloads/QGIS-OSGeo4W-{lr_version}-{lr_binary}.msi",
+        "lr_sha": f"https://download.qgis.org/downloads/QGIS-OSGeo4W-{lr_version}-{lr_binary}.sha256sum",
+        "ltr_msi": f"https://download.qgis.org/downloads/QGIS-OSGeo4W-{ltr_version}-{ltr_binary}.msi",
+        "ltr_sha": f"https://download.qgis.org/downloads/QGIS-OSGeo4W-{ltr_version}-{ltr_binary}.sha256sum",
         "weekly_msi": "https://download.osgeo.org/qgis/windows/weekly/?C=M&O=D",
     }, f, indent=4)
 

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-macos.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-macos.html
@@ -1,14 +1,14 @@
 {{ with index .Site.Data.conf }}
 <a
     class="button is-primary1 mb-3"
-    href="https://qgis.org/downloads/macos/qgis-macos-ltr.dmg"
+    href="https://download.qgis.org/downloads/macos/qgis-macos-ltr.dmg"
     onclick="thanks(this)"
     download
 >Long Term Version for Mac OS ({{ .ltrversion }} {{ .ltrnote }})</a>
 
 <a
     class="button is-primary1 is-outlined mb-3"
-    href="https://qgis.org/downloads/macos/qgis-macos-pr.dmg"
+    href="https://download.qgis.org/downloads/macos/qgis-macos-pr.dmg"
     onclick="thanks(this)"
     download
 >Latest Version for Mac OS ({{ .version }})</a>


### PR DESCRIPTION
This is the proposed fix for the download.
I wonder if we could put the direct link to the download (https://download.qgis.org/downloads/) instead of redirecting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated all download links for QGIS to point to the correct locations at `download.qgis.org` across multiple sections of the documentation and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->