### PR TITLE
undo redirect stuff and use relative links for downloads urls

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -443,12 +443,6 @@ sectionPagesMenu = 'main'
   url = "/resources/support/security"
   weight = 190
 
-[outputFormats.Redirects]
-mediaType = "text/plain"
-baseName = "_redirects"
-isPlainText = true
-notAlternative = true
-
 [outputs]
-  home = ["HTML", "RSS", "JSON", "Redirects"]
+  home = ["HTML", "RSS", "JSON"]
 

--- a/scripts/update-schedule.py
+++ b/scripts/update-schedule.py
@@ -253,11 +253,11 @@ with open("data/conf.json", "w") as f:
         "devcite": f"https://docs.qgis.org/{ltrversion}/en/docs/developers_guide/index.html",
         "userguidecite": f"https://docs.qgis.org/{ltrversion}/en/docs/user_manual/index.html",
         "servercite": f"https://docs.qgis.org/{ltrversion}/en/docs/server_manual/index.html",
-        "apicite": f"https://qgis.org/pyqgis/{ltrversion}/index.html",
-        "lr_msi": f"https://qgis.org/downloads/QGIS-OSGeo4W-{lr_version}-{lr_binary}.msi",
-        "lr_sha": f"https://qgis.org/downloads/QGIS-OSGeo4W-{lr_version}-{lr_binary}.sha256sum",
-        "ltr_msi": f"https://qgis.org/downloads/QGIS-OSGeo4W-{ltr_version}-{ltr_binary}.msi",
-        "ltr_sha": f"https://qgis.org/downloads/QGIS-OSGeo4W-{ltr_version}-{ltr_binary}.sha256sum",
+        "apicite": f"/pyqgis/{ltrversion}/index.html",
+        "lr_msi": f"/downloads/QGIS-OSGeo4W-{lr_version}-{lr_binary}.msi",
+        "lr_sha": f"/downloads/QGIS-OSGeo4W-{lr_version}-{lr_binary}.sha256sum",
+        "ltr_msi": f"/downloads/QGIS-OSGeo4W-{ltr_version}-{ltr_binary}.msi",
+        "ltr_sha": f"/downloads/QGIS-OSGeo4W-{ltr_version}-{ltr_binary}.sha256sum",
         "weekly_msi": "https://download.osgeo.org/qgis/windows/weekly/?C=M&O=D",
     }, f, indent=4)
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,0 @@
-/downloads/*   https://downloads.qgis.org/:splat   301
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed the `Redirects` output format from the `home` section in the configuration file.

- **Chores**
	- Updated URLs in scheduling scripts to use relative paths instead of full domain names for better maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->