### PR TITLE
Show current and next releases in the roadmap counter box

### DIFF
--- a/data/conf.json
+++ b/data/conf.json
@@ -18,6 +18,8 @@
     "nextreleasedate": "2024-10-25 12:00:00 UTC",
     "nextpointreleasedate": "2024-07-19 12:00:00 UTC",
     "infeaturefreeze": false,
+    "next_ltr_version": "3.34.9",
+    "next_lr_version": "3.38.1",
     "yeartag": "%%Y",
     "devcite": "https://docs.qgis.org/3.34/en/docs/developers_guide/index.html",
     "userguidecite": "https://docs.qgis.org/3.34/en/docs/user_manual/index.html",

--- a/playwright/ci-test/tests/fixtures/roadmap-page.ts
+++ b/playwright/ci-test/tests/fixtures/roadmap-page.ts
@@ -26,7 +26,7 @@ export class RoadmapPage {
     public readonly textList: string[] = [
         "Road Map",
         "Stable Release",
-        "Development Version",
+        "Latest Release",
         "Development phase",
         "Feature freeze",
         "Release",

--- a/playwright/ci-test/tests/fixtures/roadmap-page.ts
+++ b/playwright/ci-test/tests/fixtures/roadmap-page.ts
@@ -25,8 +25,9 @@ export class RoadmapPage {
     public readonly macOS: Locator;
     public readonly textList: string[] = [
         "Road Map",
-        "Stable Release",
+        "Long Term Release (LTR)",
         "Latest Release",
+        "Development Version",
         "Development phase",
         "Feature freeze",
         "Release",

--- a/scripts/update-schedule.py
+++ b/scripts/update-schedule.py
@@ -37,6 +37,9 @@ lr_version = None
 lr_is_ltr = False
 lr_date = None
 
+next_ltr_version = None
+next_lr_version = None
+
 now = datetime.now(timezone.utc)
 
 ocal = Calendar.from_ical(open("scripts/schedule.ics").read())
@@ -135,6 +138,8 @@ for row in reader:
     if dt > now:
         if "PR" in event and pr_date is None:
             pr_date = dt
+            next_lr_version = lr
+            next_ltr_version = ltr
 
         if ("LR" in event or "LTR" in event) and nr_date is None:
             nr_date = dt
@@ -247,6 +252,8 @@ with open("data/conf.json", "w") as f:
         "nextreleasedate": nr_date.strftime('%Y-%m-%d %H:%M:%S UTC') if nr_date is not None else None,
         "nextpointreleasedate": pr_date.strftime('%Y-%m-%d %H:%M:%S UTC'),
         "infeaturefreeze": f_date < now,
+        "next_ltr_version": next_ltr_version,
+        "next_lr_version": next_lr_version,
 
         # additional params:
         "yeartag": "%%Y",

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/roadmap.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/roadmap.sass
@@ -4,6 +4,7 @@
     &:hover
       color: black
   .rm-future
+    font-weight: 600
     color: #4D6370
   .rm-current
     font-weight: 600
@@ -171,8 +172,10 @@ div
 .right-ribbon
   .stable
     background: #3a9800
-  .development
+  .latest
     background: #ee7913
+  .development
+    background: #4D6370
 
 
 .right-ribbon span::before
@@ -188,9 +191,13 @@ div
   border-left: 3px solid #3a9800
   border-top: 3px solid #3a9800
 
-.right-ribbon .development::before
+.right-ribbon .latest::before
   border-left: 3px solid #ee7913
   border-top: 3px solid #ee7913
+
+.right-ribbon .development::before
+  border-left: 3px solid #4D6370
+  border-top: 3px solid #4D6370
 
 .right-ribbon span::after
   content: ''
@@ -205,6 +212,10 @@ div
   border-right: 3px solid #3a9800
   border-top: 3px solid #3a9800
 
-.right-ribbon .development::after
+.right-ribbon .latest::after
   border-right: 3px solid #ee7913
   border-top: 3px solid #ee7913
+
+.right-ribbon .development::after
+  border-right: 3px solid #4D6370
+  border-top: 3px solid #4D6370

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/roadmap.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/roadmap.sass
@@ -26,7 +26,7 @@ div
   margin-left: 0rem 
   .steps-content
     margin-top: 0.5rem
-    max-width: 140px
+    max-width: 150px
     +mobile
       max-width: 100%
 

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/roadmap.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/roadmap.sass
@@ -28,6 +28,7 @@ div
   .steps-content
     margin-top: 0.5rem
     max-width: 200px
+    font-size: 11pt
     +mobile
       max-width: 100%
     div
@@ -67,16 +68,13 @@ div
     +mobile
       margin-left: 0.75rem
 
-
 .help-tip
-  // position: absolute
   text-align: center
   background-color: #dbe5eb
   border-radius: 50%
   width: 24px
   height: 24px
   font-size: 14px
-  // line-height: 26px
   cursor: default
   margin: 3px 5px 0px 0px
   +mobile

--- a/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/roadmap.sass
+++ b/themes/hugo-bulma-blocks-theme/assets/sass/bulma/components/roadmap.sass
@@ -20,15 +20,19 @@ div
   &.roadmap
     background: #f4f7f9
     padding: 2rem
-    border-radius: 10px  
+    border-radius: 10px
+    position: relative  
 
 .content .steps
   margin-left: 0rem 
   .steps-content
     margin-top: 0.5rem
-    max-width: 150px
+    max-width: 200px
     +mobile
       max-width: 100%
+    div
+      +mobile
+        display: block !important
 
   .tag
     margin-top: 0.25rem
@@ -59,22 +63,23 @@ div
   .steps:not(.is-hollow) .steps-segment.is-active ~ .steps-segment .steps-marker:not(.is-hollow), .steps-segment.is-active ~ .steps-segment:after, .steps-segment.is-active:after
     background-color: #dbe5eb
   .steps:not(.is-vertical) .steps-content
-    margin-left: 0.75rem
+    margin-left: 0
+    +mobile
+      margin-left: 0.75rem
 
 
 .help-tip
-  position: absolute
+  // position: absolute
   text-align: center
   background-color: #dbe5eb
   border-radius: 50%
   width: 24px
   height: 24px
   font-size: 14px
-  line-height: 26px
+  // line-height: 26px
   cursor: default
-  margin: 3px 0px 0px 5px
+  margin: 3px 5px 0px 0px
   +mobile
-        display: block
         width: 100%
         height: auto
         position: relative
@@ -141,11 +146,67 @@ div
       +mobile
         display: none !important
 
+.right-ribbon
+  position: absolute
+  right: -5px
+  top: -5px
+  z-index: 1
+  overflow: hidden
+  width: 150px
+  height: 150px
+  text-align: right
+
+.right-ribbon span
+  color: #fff
+  text-align: center
+  font-size: 14pt
+  font-weight: 500
+  line-height: 40px
+  transform: rotate(45deg)
+  width: 200px
+  display: block
+  box-shadow: 0 3px 10px -5px rgba(0, 0, 0, 1)
+  position: absolute
+  top: 39px
+  right: -41px
+
+.right-ribbon
+  .stable
+    background: #3a9800
+  .development
+    background: #ee7913
 
 
+.right-ribbon span::before
+  content: ''
+  position: absolute
+  left: 0px
+  top: 100%
+  z-index: -1
+  border-right: 3px solid transparent
+  border-bottom: 3px solid transparent
 
+.right-ribbon .stable::before
+  border-left: 3px solid #3a9800
+  border-top: 3px solid #3a9800
 
+.right-ribbon .development::before
+  border-left: 3px solid #ee7913
+  border-top: 3px solid #ee7913
 
+.right-ribbon span::after
+  content: ''
+  position: absolute
+  right: 0%
+  top: 100%
+  z-index: -1
+  border-left: 3px solid transparent
+  border-bottom: 3px solid transparent
 
+.right-ribbon .stable::after
+  border-right: 3px solid #3a9800
+  border-top: 3px solid #3a9800
 
-    
+.right-ribbon .development::after
+  border-right: 3px solid #ee7913
+  border-top: 3px solid #ee7913

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap copy.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap copy.html
@@ -191,6 +191,7 @@
       
       var deadline = new Date(Date.parse(new Date()) + 15 * 24 * 60 * 60 * 1000);
       initializeClock('point-release', deadline);
+      initializeClock('latest-point-release', deadline);
       initializeClock('freeze', deadline);
       initializeClock('package', deadline);
     </script>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
@@ -1,9 +1,9 @@
 <div class="container">
-    <div class="roadmap  mb-2">
+    <div class="roadmap  mb-4">
         {{ with index .Site.Data.conf }}
             <div class="right-ribbon"><span class="stable">Current: {{ .ltrversion }}</span></div>
         {{ end }}
-    <h3 class="title">Stable Release</h3>
+    <h3 class="title">Long Term Release (LTR)</h3>
     <ul class="steps is-balanced">
         <li class="steps-segment">
             <span class="steps-marker"></span>
@@ -87,25 +87,26 @@
     </ul>
     </div>
 
-    <div class="roadmap  mb-6">
+    <div class="roadmap  mb-4">
     {{ with index .Site.Data.conf }}
-        <div class="right-ribbon"><span class="development">Current: {{ .version }}</span></div>
+        <div class="right-ribbon"><span class="latest">Current: {{ .version }}</span></div>
     {{ end }}
     <h3 class="title">Latest Release</h3>
     <ul class="steps is-balanced">
         <li class="steps-segment">
             <span class="steps-marker"></span>
             <div class="steps-content">
-            <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
-                <span>Active development</span>
-                <span class="help-tip">
-                    <span > This is the open stage for accepting new features.</span>
+            <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                <span>
+                    Initial Release 
                 </span>
-
+                <span class="help-tip">
+                    <span > Our stable releases are created by periodically taking a development version and 'hardening' it by focussing only on bugfixes. </span>
+                 </span>
             </div>
-            </div>
+            
         </li>
-        <li class="steps-segment">
+        <li class="steps-segment is-active">
             <span class="steps-marker"></span>
             <div class="steps-content">
                 <div>
@@ -149,91 +150,14 @@
                 </div>
             </div>
         </li>
-        <li class="steps-segment">
-            <span class="steps-marker"></span>
-            <div class="steps-content">
-                <div>
-                    <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
-                        <span>
-                            Feature freeze:
-                            {{ with index .Site.Data.conf }}
-                                <span class="rm-next">{{ .devversion }}</span>
-                            {{ end }}
-                        </span>
-                        <span class="help-tip">
-                            <span > During feature freeze, no new features are accepted, only bug fixes and code clean ups.</span>
-                        </span>
-                    </div>
-                    <nav id="freeze" class="level">
-                        <div class="level-item is-narrow has-text-centered">
-                            <div>
-                                <p class="days heading is-size-7 tag "></p>
-                                <p class="is-size-7">Days</p>
-                            </div>
-                        </div>
-                        <div class="level-item is-narrow has-text-centered">
-                            <div>
-                            <p class="hours heading is-size-7 tag "></p>
-                            <p class="is-size-7">Hours</p>
-                            </div>
-                        </div>
-                        <div class="level-item is-narrow has-text-centered">
-                            <div>
-                                <p class="minutes heading is-size-7 tag "></p>
-                                <p class="is-size-7">Min.</p>
-                            </div>
-                        </div>
-                        <div class="level-item is-narrow has-text-centered">
-                            <div>
-                                <p class="seconds heading is-size-7 tag "></p>
-                                <p class="is-size-7">Sec.</p>
-                            </div>
-                        </div>
-                    </nav>
-                </div>
-            </div>
-        </li>
         <li class="steps-segment is-active">
             <span class="steps-marker"></span>
             <div class="steps-content">
-                <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
-                    <span>
-                        Packaging:
-                        {{ with index .Site.Data.conf }}
-                            <span class="rm-next">{{ .nextversion }}</span>
-                        {{ end }}
-                    </span>
+                <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                    <span>Packaging</span>
                     <span class="help-tip">
-                        <span > Here we tag the release and make it available for packaging on different platforms.</span>
+                        <span > Here we tag the release and make it available for packaging on different platforms. </span>
                     </span>
-                </div>
-                <div>
-                    <nav id="package" class="level">
-                        <div class="level-item is-narrow has-text-centered">
-                            <div>
-                                <p class="days heading is-size-7 tag "></p>
-                                <p class="is-size-7">Days</p>
-                            </div>
-                        </div>
-                        <div class="level-item is-narrow has-text-centered">
-                            <div>
-                            <p class="hours heading is-size-7 tag "></p>
-                            <p class="is-size-7">Hours</p>
-                            </div>
-                        </div>
-                        <div class="level-item is-narrow has-text-centered">
-                            <div>
-                                <p class="minutes heading is-size-7 tag "></p>
-                                <p class="is-size-7">Min.</p>
-                            </div>
-                        </div>
-                        <div class="level-item is-narrow has-text-centered">
-                            <div>
-                                <p class="seconds heading is-size-7 tag "></p>
-                                <p class="is-size-7">Sec.</p>
-                            </div>
-                        </div>
-                    </nav>
                 </div>
             </div>
         </li>
@@ -250,6 +174,123 @@
             </li>
     </ul>
     </div>
+
+    <div class="roadmap  mb-6">
+        {{ with index .Site.Data.conf }}
+            <div class="right-ribbon"><span class="development">Future: {{ .nextversion }}</span></div>
+        {{ end }}
+        <h3 class="title">Development Version</h3>
+        <ul class="steps is-balanced">
+            <li class="steps-segment">
+                <span class="steps-marker"></span>
+                <div class="steps-content">
+                <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                    <span>Active development</span>
+                    <span class="help-tip">
+                        <span > This is the open stage for accepting new features.</span>
+                    </span>
+    
+                </div>
+                </div>
+            </li>
+            <li class="steps-segment">
+                <span class="steps-marker"></span>
+                <div class="steps-content">
+                    <div>
+                        <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                            <span>
+                                Feature freeze:
+                                {{ with index .Site.Data.conf }}
+                                    <span class="rm-future">{{ .devversion }}</span>
+                                {{ end }}
+                            </span>
+                            <span class="help-tip">
+                                <span > During feature freeze, no new features are accepted, only bug fixes and code clean ups.</span>
+                            </span>
+                        </div>
+                        <nav id="freeze" class="level">
+                            <div class="level-item is-narrow has-text-centered">
+                                <div>
+                                    <p class="days heading is-size-7 tag "></p>
+                                    <p class="is-size-7">Days</p>
+                                </div>
+                            </div>
+                            <div class="level-item is-narrow has-text-centered">
+                                <div>
+                                <p class="hours heading is-size-7 tag "></p>
+                                <p class="is-size-7">Hours</p>
+                                </div>
+                            </div>
+                            <div class="level-item is-narrow has-text-centered">
+                                <div>
+                                    <p class="minutes heading is-size-7 tag "></p>
+                                    <p class="is-size-7">Min.</p>
+                                </div>
+                            </div>
+                            <div class="level-item is-narrow has-text-centered">
+                                <div>
+                                    <p class="seconds heading is-size-7 tag "></p>
+                                    <p class="is-size-7">Sec.</p>
+                                </div>
+                            </div>
+                        </nav>
+                    </div>
+                </div>
+            </li>
+            <li class="steps-segment is-active">
+                <span class="steps-marker"></span>
+                <div class="steps-content">
+                    <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                        <span>
+                            Packaging
+                        </span>
+                        <span class="help-tip">
+                            <span > Here we tag the release and make it available for packaging on different platforms.</span>
+                        </span>
+                    </div>
+                    <div>
+                        <nav id="package" class="level">
+                            <div class="level-item is-narrow has-text-centered">
+                                <div>
+                                    <p class="days heading is-size-7 tag "></p>
+                                    <p class="is-size-7">Days</p>
+                                </div>
+                            </div>
+                            <div class="level-item is-narrow has-text-centered">
+                                <div>
+                                <p class="hours heading is-size-7 tag "></p>
+                                <p class="is-size-7">Hours</p>
+                                </div>
+                            </div>
+                            <div class="level-item is-narrow has-text-centered">
+                                <div>
+                                    <p class="minutes heading is-size-7 tag "></p>
+                                    <p class="is-size-7">Min.</p>
+                                </div>
+                            </div>
+                            <div class="level-item is-narrow has-text-centered">
+                                <div>
+                                    <p class="seconds heading is-size-7 tag "></p>
+                                    <p class="is-size-7">Sec.</p>
+                                </div>
+                            </div>
+                        </nav>
+                    </div>
+                </div>
+            </li>
+            <li class="steps-segment is-active">
+                <span class="steps-marker"></span>
+                <div class="steps-content">
+                    <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                        <span>Installers available</span>
+                        <span class="help-tip">
+                            <span > The exact period between packaging and the availablility of installers varies by platform as maintainers prepare their packages. See the download pages for updates on availability.</span>
+                        </span>
+                    </div>
+                </div>
+                </li>
+        </ul>
+        </div>
 </div>
 <script>
     /** Script graciously provided at https://codepen.io/SitePoint/pen/MwNPVq */

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
@@ -8,7 +8,7 @@
         <li class="steps-segment">
             <span class="steps-marker"></span>
             <div class="steps-content">
-            <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+            <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                 <span>
                     Initial Release 
                 </span>
@@ -22,7 +22,7 @@
             <span class="steps-marker"></span>
             <div class="steps-content">
                 <div>
-                    <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                    <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                         <span>
                             Point Release:
                             {{ with index .Site.Data.conf }}
@@ -65,7 +65,7 @@
         <li class="steps-segment is-active">
             <span class="steps-marker"></span>
             <div class="steps-content">
-                <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                     <span>Packaging</span>
                     <span class="help-tip">
                         <span > Here we tag the release and make it available for packaging on different platforms. </span>
@@ -76,7 +76,7 @@
         <li class="steps-segment is-active">
             <span class="steps-marker"></span>
             <div class="steps-content">
-                <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                     <span>Installers available</span>
                     <span class="help-tip">
                         <span > The exact period between packaging and the availablility of installers varies by platform as maintainers prepare their packages. See the download pages for updates on availability.</span>
@@ -96,7 +96,7 @@
         <li class="steps-segment">
             <span class="steps-marker"></span>
             <div class="steps-content">
-            <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+            <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                 <span>
                     Initial Release 
                 </span>
@@ -110,7 +110,7 @@
             <span class="steps-marker"></span>
             <div class="steps-content">
                 <div>
-                    <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                    <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                         <span>
                             Point Release:
                             {{ with index .Site.Data.conf }}
@@ -153,7 +153,7 @@
         <li class="steps-segment is-active">
             <span class="steps-marker"></span>
             <div class="steps-content">
-                <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                     <span>Packaging</span>
                     <span class="help-tip">
                         <span > Here we tag the release and make it available for packaging on different platforms. </span>
@@ -164,7 +164,7 @@
         <li class="steps-segment is-active">
             <span class="steps-marker"></span>
             <div class="steps-content">
-                <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                     <span>Installers available</span>
                     <span class="help-tip">
                         <span > The exact period between packaging and the availablility of installers varies by platform as maintainers prepare their packages. See the download pages for updates on availability.</span>
@@ -184,7 +184,7 @@
             <li class="steps-segment">
                 <span class="steps-marker"></span>
                 <div class="steps-content">
-                <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                     <span>Active development</span>
                     <span class="help-tip">
                         <span > This is the open stage for accepting new features.</span>
@@ -197,7 +197,7 @@
                 <span class="steps-marker"></span>
                 <div class="steps-content">
                     <div>
-                        <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                        <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                             <span>
                                 Feature freeze:
                                 {{ with index .Site.Data.conf }}
@@ -240,7 +240,7 @@
             <li class="steps-segment is-active">
                 <span class="steps-marker"></span>
                 <div class="steps-content">
-                    <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                    <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                         <span>
                             Packaging
                         </span>
@@ -281,7 +281,7 @@
             <li class="steps-segment is-active">
                 <span class="steps-marker"></span>
                 <div class="steps-content">
-                    <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                    <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left is-align-items-center">
                         <span>Installers available</span>
                         <span class="help-tip">
                             <span > The exact period between packaging and the availablility of installers varies by platform as maintainers prepare their packages. See the download pages for updates on availability.</span>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
@@ -91,7 +91,7 @@
     {{ with index .Site.Data.conf }}
         <div class="right-ribbon"><span class="development">Current: {{ .version }}</span></div>
     {{ end }}
-    <h3 class="title">Development Version</h3>
+    <h3 class="title">Latest Release</h3>
     <ul class="steps is-balanced">
         <li class="steps-segment">
             <span class="steps-marker"></span>
@@ -110,7 +110,56 @@
             <div class="steps-content">
                 <div>
                     <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
-                        <span>Feature freeze</span>
+                        <span>
+                            Point Release:
+                            {{ with index .Site.Data.conf }}
+                                <span class="rm-next">{{ .next_lr_version }}</span>
+                            {{ end }}
+                        </span>
+                        <span class="help-tip">
+                            <span > Each month we create a new point release for our latest version. These releases contain no new features, only bug fixes. </span>
+                        </span>
+                    </div>
+                    <nav id="latest-point-release" class="level">
+                        <div class="level-item is-narrow has-text-centered">
+                            <div>
+                                <p class="days heading is-size-7 tag "></p>
+                                <p class="is-size-7"> Days  </p>
+                            </div>
+                        </div>
+                        <div class="level-item is-narrow has-text-centered">
+                            <div>
+                            <p class="hours heading is-size-7 tag "></p>
+                            <p class="is-size-7"> Hours </p>
+                            </div>
+                        </div>
+                        <div class="level-item is-narrow has-text-centered">
+                            <div>
+                                <p class="minutes heading is-size-7 tag "></p>
+                                <p class="is-size-7">Min.</p>
+                            </div>
+                        </div>
+                        <div class="level-item is-narrow has-text-centered">
+                            <div>
+                                <p class="seconds heading is-size-7 tag "></p>
+                                <p class="is-size-7">Sec.</p>
+                            </div>
+                        </div>
+                    </nav>
+                </div>
+            </div>
+        </li>
+        <li class="steps-segment">
+            <span class="steps-marker"></span>
+            <div class="steps-content">
+                <div>
+                    <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                        <span>
+                            Feature freeze:
+                            {{ with index .Site.Data.conf }}
+                                <span class="rm-next">{{ .devversion }}</span>
+                            {{ end }}
+                        </span>
                         <span class="help-tip">
                             <span > During feature freeze, no new features are accepted, only bug fixes and code clean ups.</span>
                         </span>
@@ -148,7 +197,12 @@
             <span class="steps-marker"></span>
             <div class="steps-content">
                 <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
-                    <span>Packaging</span>
+                    <span>
+                        Packaging:
+                        {{ with index .Site.Data.conf }}
+                            <span class="rm-next">{{ .nextversion }}</span>
+                        {{ end }}
+                    </span>
                     <span class="help-tip">
                         <span > Here we tag the release and make it available for packaging on different platforms.</span>
                     </span>
@@ -251,6 +305,7 @@
       const nextPointReleaseDate = new Date(nextPointReleaseDateStr.replace(" ", "T").replace(" UTC", "Z"))
 
       initializeClock('point-release', nextPointReleaseDate);
+      initializeClock('latest-point-release', nextPointReleaseDate);
       initializeClock('freeze', nextFreezeDate);
       initializeClock('package', nextReleaseDate);
     </script>

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
@@ -10,6 +10,15 @@
                     <span > Our stable releases are created by periodically taking a development version and 'hardening' it by focussing only on bugfixes. </span>
                  </span>
             </div>
+            {{ with index .Site.Data.conf }}
+                <div>
+                    Current releases:
+                    <ul class="rm-current">
+                        <li>{{ .ltrrelease }}</li>
+                        <li>{{ .release }}</li>
+                    </ul>
+                </div>
+            {{ end }}
             
         </li>
         <li class="steps-segment is-active">
@@ -68,8 +77,17 @@
                         <span > The exact period between packaging and the availablility of installers varies by platform as maintainers prepare their packages. See the download pages for updates on availability.</span>
                     </span>
                 </div>
+                {{ with index .Site.Data.conf }}
+                    <div>
+                        Next releases: 
+                        <ul class="rm-next">
+                            <li>{{ .next_ltr_version }}</li>
+                            <li>{{ .next_lr_version }}</li>
+                        </ul>
+                    </div>
+                {{ end }}
             </div>
-            </li>
+        </li>
     </ul>
     </div>
 
@@ -83,7 +101,14 @@
                 <span class="help-tip">
                     <span > This is the open stage for accepting new features.</span>
                 </span>
+
             </div>
+            {{ with index .Site.Data.conf }}
+                <div>
+                    Current version: 
+                    <ul class="rm-current"><li>{{ .devversion }}</li></ul> 
+                </div>
+            {{ end }}
             </div>
         </li>
         <li class="steps-segment">

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/roadmap.html
@@ -1,31 +1,34 @@
 <div class="container">
     <div class="roadmap  mb-2">
+        {{ with index .Site.Data.conf }}
+            <div class="right-ribbon"><span class="stable">Current: {{ .ltrversion }}</span></div>
+        {{ end }}
     <h3 class="title">Stable Release</h3>
     <ul class="steps is-balanced">
         <li class="steps-segment">
             <span class="steps-marker"></span>
             <div class="steps-content">
-            <div class=" has-text-weight-normal">Initial Release 
+            <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                <span>
+                    Initial Release 
+                </span>
                 <span class="help-tip">
                     <span > Our stable releases are created by periodically taking a development version and 'hardening' it by focussing only on bugfixes. </span>
                  </span>
             </div>
-            {{ with index .Site.Data.conf }}
-                <div>
-                    Current releases:
-                    <ul class="rm-current">
-                        <li>{{ .ltrrelease }}</li>
-                        <li>{{ .release }}</li>
-                    </ul>
-                </div>
-            {{ end }}
             
         </li>
         <li class="steps-segment is-active">
             <span class="steps-marker"></span>
             <div class="steps-content">
                 <div>
-                    <div class=" has-text-weight-normal">Point Release
+                    <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                        <span>
+                            Point Release:
+                            {{ with index .Site.Data.conf }}
+                                <span class="rm-current">{{ .next_ltr_version }}</span>
+                            {{ end }}
+                        </span>
                         <span class="help-tip">
                             <span > Each month we create a new point release for our stable version. These releases contain no new features, only bug fixes. </span>
                         </span>
@@ -62,7 +65,8 @@
         <li class="steps-segment is-active">
             <span class="steps-marker"></span>
             <div class="steps-content">
-                <div class=" has-text-weight-normal">Packaging
+                <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                    <span>Packaging</span>
                     <span class="help-tip">
                         <span > Here we tag the release and make it available for packaging on different platforms. </span>
                     </span>
@@ -72,50 +76,41 @@
         <li class="steps-segment is-active">
             <span class="steps-marker"></span>
             <div class="steps-content">
-                <div class=" has-text-weight-normal">Installers available
+                <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                    <span>Installers available</span>
                     <span class="help-tip">
                         <span > The exact period between packaging and the availablility of installers varies by platform as maintainers prepare their packages. See the download pages for updates on availability.</span>
                     </span>
                 </div>
-                {{ with index .Site.Data.conf }}
-                    <div>
-                        Next releases: 
-                        <ul class="rm-next">
-                            <li>{{ .next_ltr_version }}</li>
-                            <li>{{ .next_lr_version }}</li>
-                        </ul>
-                    </div>
-                {{ end }}
             </div>
         </li>
     </ul>
     </div>
 
     <div class="roadmap  mb-6">
+    {{ with index .Site.Data.conf }}
+        <div class="right-ribbon"><span class="development">Current: {{ .version }}</span></div>
+    {{ end }}
     <h3 class="title">Development Version</h3>
     <ul class="steps is-balanced">
         <li class="steps-segment">
             <span class="steps-marker"></span>
             <div class="steps-content">
-            <div class=" has-text-weight-normal">Active development
+            <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                <span>Active development</span>
                 <span class="help-tip">
                     <span > This is the open stage for accepting new features.</span>
                 </span>
 
             </div>
-            {{ with index .Site.Data.conf }}
-                <div>
-                    Current version: 
-                    <ul class="rm-current"><li>{{ .devversion }}</li></ul> 
-                </div>
-            {{ end }}
             </div>
         </li>
         <li class="steps-segment">
             <span class="steps-marker"></span>
             <div class="steps-content">
                 <div>
-                    <div class=" has-text-weight-normal">Feature freeze
+                    <div class="has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                        <span>Feature freeze</span>
                         <span class="help-tip">
                             <span > During feature freeze, no new features are accepted, only bug fixes and code clean ups.</span>
                         </span>
@@ -152,7 +147,8 @@
         <li class="steps-segment is-active">
             <span class="steps-marker"></span>
             <div class="steps-content">
-                <div class=" has-text-weight-normal">Packaging
+                <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                    <span>Packaging</span>
                     <span class="help-tip">
                         <span > Here we tag the release and make it available for packaging on different platforms.</span>
                     </span>
@@ -190,7 +186,8 @@
         <li class="steps-segment is-active">
             <span class="steps-marker"></span>
             <div class="steps-content">
-                <div class=" has-text-weight-normal">Installers available
+                <div class=" has-text-weight-normal is-flex is-flex-direction-row-reverse is-justify-content-left">
+                    <span>Installers available</span>
                     <span class="help-tip">
                         <span > The exact period between packaging and the availablility of installers varies by platform as maintainers prepare their packages. See the download pages for updates on availability.</span>
                     </span>


### PR DESCRIPTION
This is the proposed fix for #311 

![image](https://github.com/qgis/QGIS-Hugo/assets/43842786/eda77b19-4835-4ed3-9945-90a0ca6bc583)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new layout for the roadmap to display release information, including version numbers and descriptions for Stable Release and Development Version milestones.
  
- **Style**
  - Adjusted styles for roadmap elements to improve readability and alignment, particularly on mobile devices.
  - Added styles for a new `.right-ribbon` element to indicate different release states: `stable`, `latest`, and `development`.
  - Enhanced visual hierarchy with updated `font-size` and `font-weight` adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->