### PR TITLE
Use relative links for source and macos download

### DIFF
--- a/content/download/index.md
+++ b/content/download/index.md
@@ -85,7 +85,7 @@ After installing QGIS, the first launch attempt may fail due to Apple's security
 {{< spoiler-start title="📃 Source Code" >}}
 QGIS is open source software available under the terms of the <b>GNU General Public License</b> meaning that its source code can be downloaded through 'tarballs' or the git repository.
 
-QGIS Source Code is available <a href="https://qgis.org/downloads/qgis-latest.tar.bz2">here (latest release)</a> and <a href="https://qgis.org/downloads/qgis-latest-ltr.tar.bz2">here (long term release)</a>
+QGIS Source Code is available <a href="/downloads/qgis-latest.tar.bz2">here (latest release)</a> and <a href="/downloads/qgis-latest-ltr.tar.bz2">here (long term release)</a>
 
 Refer to the installation guide on how to compile QGIS from source for the different platforms: [here](https://github.com/qgis/QGIS/blob/master/INSTALL.md)
 

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-macos.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-macos.html
@@ -1,14 +1,14 @@
 {{ with index .Site.Data.conf }}
 <a
     class="button is-primary1 mb-3"
-    href="https://qgis.org/downloads/macos/qgis-macos-ltr.dmg"
+    href="/downloads/macos/qgis-macos-ltr.dmg"
     onclick="thanks(this)"
     download
 >Long Term Version for Mac OS ({{ .ltrversion }} {{ .ltrnote }})</a>
 
 <a
     class="button is-primary1 is-outlined mb-3"
-    href="https://qgis.org/downloads/macos/qgis-macos-pr.dmg"
+    href="/downloads/macos/qgis-macos-pr.dmg"
     onclick="thanks(this)"
     download
 >Latest Version for Mac OS ({{ .version }})</a>


### PR DESCRIPTION
Relative link for source download and macos download

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated download URLs to use relative paths for easier maintenance and consistency across the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->