### PR TITLE
Add the goodies link to the sidebar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -294,11 +294,18 @@ sectionPagesMenu = 'main'
   weight = 5 # Sets the menu order 
   #pre = "<i class='fa-solid fa-handshake-angle mr-1'></i>"  
 
+
+[[menu.main]]
+  # parent = "Funding"
+  name = "Goodies"
+  url = "/goodies"
+  weight = 60
+
 [[menu.main]]
   name = "Download"
   url = "/download/"
   #pre = "<i class='fa-solid fa-circle-down mr-1'></i>"
-  weight = 60 # Sets the menu order 
+  weight = 80 # Sets the menu order 
 
 [[menu.main]]
   name = "Funding"


### PR DESCRIPTION
This is the proposed fix for #315

I've only added it to the sidebar as it already exists in the footer.

![image](https://github.com/qgis/QGIS-Hugo/assets/43842786/0be9d940-4bf6-4498-a3ca-bb0ee48899dd)

![image](https://github.com/qgis/QGIS-Hugo/assets/43842786/cd51920f-e1ea-4a88-9011-534e306c9de8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added "Goodies" menu item to the main menu, linking to "/goodies."

- **Improvements**
  - Adjusted the position of the "Download" menu item in the main menu for better accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->