### PR TITLE
Fix title of Goodies page

### DIFF
--- a/content/goodies/index.md
+++ b/content/goodies/index.md
@@ -1,6 +1,6 @@
 ---
 type: "page"
-title: "Diversity statement"
+title: "Goodies"
 subtitle: ""
 draft: false
 sidebar: true


### PR DESCRIPTION
The Goodies page had the wrong title, probably from copy'n'paste. :rainbow: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated page title from "Diversity statement" to "Goodies" for better alignment with content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->