### PR TITLE
Update to the 3.38 changelog video

### DIFF
--- a/themes/hugo-bulma-blocks-theme/layouts/partials/explore.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/partials/explore.html
@@ -72,7 +72,7 @@
         <iframe
             width="560"
             height="315"
-            src="https://www.youtube.com/embed/q7O819lFKc4?si=RQ4nw9yqdEAAONpe"
+            src="https://www.youtube.com/embed/oktjj7xBZ54"
             title="YouTube video player"
             frameborder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"


### PR DESCRIPTION
Currently the visual changelog video for 3.30 is embedded (https://www.youtube.com/watch?v=q7O819lFKc4).

This switches the embed on the homepage to 3.38 (https://www.youtube.com/watch?v=oktjj7xBZ54).

Also removes some unnecessary tracking parameter.