### PR TITLE
Fix installation guide link in thank-you page

### DIFF
--- a/content/thank-you/index.md
+++ b/content/thank-you/index.md
@@ -17,7 +17,7 @@ url: "/download/thank-you"
 {{< rich-content-start themeClass="coloring-1" >}}
 ##### Tips for first launch
 If you have any questions while starting QGIS, welcome to our complete guide to installing for the first time.
-<a href="resources/installation-guide">Installation guide  </a>
+<a href="/resources/installation-guide">Installation guide  </a>
 {{< rich-content-end >}}
 {{< rich-box-end >}}
 


### PR DESCRIPTION
This is the proposed fix for #329 

The installation guide link in https://qgis.org/download/thank-you/  that is currently pointing to https://qgis.org/download/thank-you/resources/installation-guide should be pointing to https://qgis.org/resources/installation-guide/ instead.

I think this will save us from adding another redirection rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the URL for the Installation guide in the Thank You page to ensure the link directs correctly to the resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->