### PR TITLE
fix Mergin Maps links

### DIFF
--- a/content/project/overview.md
+++ b/content/project/overview.md
@@ -183,7 +183,7 @@ Benefit from the powerful symbology, labeling and blending features to impress t
 The QGIS experience does not stop on the desktop. Various third-party touch optimized apps allow you to take QGIS out of the office.
 
 * [QField]({{< ref "download.md" >}})
-* [Mergin Maps Input app]({{< ref "download.md" >}})
+* [Mergin Maps mobile app]({{< ref "download.md" >}})
 * [IntraMaps Roam]({{< ref "download.md" >}})
 
 {{< rich-content-end >}}

--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/mobile-downloads.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/mobile-downloads.html
@@ -7,12 +7,12 @@
 	<a href="https://qfield.org/get_latest/?platform=windows"><img alt="Get it for Windows" src="{{ absURL "img/app_download_windows.png" }}"></a>
 	<a href="https://www.github.com/opengisch/qfield/releases"><img alt="Get it on GitHub" src="{{ absURL "img/app_download_gh.png" }}"></a>
 </div>
-<a href="https://merginmaps.com/">Mergin Maps Input app (available for Android, iOS and Windows devices)</a>
+<a href="https://merginmaps.com/">Mergin Maps mobile app (available for Android, iOS and Windows devices)</a>
 <div>
 	<a href="https://play.google.com/store/apps/details?id=uk.co.lutraconsulting&amp;utm_source=qgis.org"><img alt="Get it on Google Play" src="{{ absURL "img/app_download_play_store.png" }}"></a>
-	<a href="https://apps.apple.com/us/app/input/id1478603559"><img alt="Get it for iOS" src="{{ absURL "img/app_download_apple_store.png" }}"></a>
-	<a href="https://www.github.com/MerginMaps/input/releases"><img alt="Get it for Windows" src="{{ absURL "img/app_download_windows.png" }}"></a>
-	<a href="https://www.github.com/MerginMaps/input/releases"><img alt="Get it on GitHub" src="{{ absURL "img/app_download_gh.png" }}"></a>
+	<a href="https://apps.apple.com/us/app/mergin-maps-qgis-in-pocket/id1478603559"><img alt="Get it for iOS" src="{{ absURL "img/app_download_apple_store.png" }}"></a>
+	<a href="https://www.github.com/MerginMaps/mobile/releases"><img alt="Get it for Windows" src="{{ absURL "img/app_download_windows.png" }}"></a>
+	<a href="https://www.github.com/MerginMaps/mobile/releases"><img alt="Get it on GitHub" src="{{ absURL "img/app_download_gh.png" }}"></a>
 </div>
 <a href="https://roam-docs.readthedocs.io">IntraMaps Roam</a>
 <div>


### PR DESCRIPTION
Mergin Maps project does not use "Input app" anymore, I fixed the naming to "Mergin Maps mobile app" and replaced obsolete links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Renamed "Mergin Maps Input app" to "Mergin Maps mobile app" in the project overview.

- **New Features**
  - Updated links and descriptions for Mergin Maps on Android, iOS, and Windows platforms in the mobile downloads section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->