### PR TITLE
Fix broken image in the thank-you page

### DIFF
--- a/content/thank-you/index.md
+++ b/content/thank-you/index.md
@@ -49,7 +49,7 @@ Join a community of like-minded individuals in your region.
 [Local groups list]({{< ref "community/groups.md" >}})
 {{< rich-content-end >}}
 {{< rich-right-start >}}  
-![Local user groups](../../project/img/groupss.jpg "Local user groups")
+![Local user groups](../../project/img/groups.jpg "Local user groups")
 {{< rich-right-end >}}
 {{< rich-box-end >}}
 


### PR DESCRIPTION
This PR is a proposed fix for the broken user group image at https://qgis.org/download/thank-you/ 

![image](https://github.com/user-attachments/assets/dd68a2be-f390-4121-8d03-e290d4340a2f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in an image file path to ensure the local user groups image displays correctly on the community page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->