### PR TITLE
Fix archive link place

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -314,6 +314,12 @@ sectionPagesMenu = 'main'
   weight = 80 # Sets the menu order 
 
 [[menu.main]]
+  name = "Archive"
+  url = "/archive/"
+  #pre = "<i class='fa-solid fa-circle-down mr-1'></i>"
+  weight = 90 # Sets the menu order 
+
+[[menu.main]]
   name = "Funding"
   url = "/funding/donate"
   #pre = "<i class='fa-solid fa-circle-down mr-1'></i>"
@@ -358,12 +364,6 @@ sectionPagesMenu = 'main'
   url = "/resources/installation-guide/"
   weight = 10
 
-
-[[menu.main]]
-  parent = "Resources"
-  name = "Releases"
-  url = "/resources/releases/"
-  weight = 30
 
 [[menu.main]]
   parent = "Resources"

--- a/content/archive/index.md
+++ b/content/archive/index.md
@@ -1,6 +1,6 @@
 ---
 type: "page"
-title: "Releases"
+title: "Archive"
 subtitle: ""
 draft: false
 sidebar: true
@@ -10,7 +10,7 @@ Reviewer: Tim Sutton
 
 {{< content-start  >}}
 
-# Release Archive
+# Archive
 
 Previous releases of QGIS are available at the following locations:
 

--- a/playwright/ci-test/tests/01-home-page.spec.ts
+++ b/playwright/ci-test/tests/01-home-page.spec.ts
@@ -50,7 +50,6 @@ test.describe("Home page", () => {
         await header.resourcesLink.hover();
         await expect(header.documentationLink).toBeVisible();
         await expect(header.installationGuideLink).toBeVisible();
-        await expect(header.releasesLink).toBeVisible();
         await expect(header.roadmapLink).toBeVisible();
         await expect(header.reportsLink).toBeVisible();
         await expect(header.booksLink).toBeVisible();
@@ -112,7 +111,7 @@ test.describe("Home page", () => {
         await expect(footer.membersBlogsList).toBeVisible();
         await expect(footer.documentationLink).toBeVisible();
         await expect(footer.installationGuideLink).toBeVisible();
-        await expect(footer.releasesLink).toBeVisible();
+        await expect(footer.archiveLink).toBeVisible();
         await expect(footer.roadmapLink).toBeVisible();
         await expect(footer.reportsLink).toBeVisible();
         await expect(footer.booksLink).toBeVisible();

--- a/playwright/ci-test/tests/06-resources-page.spec.ts
+++ b/playwright/ci-test/tests/06-resources-page.spec.ts
@@ -2,7 +2,6 @@ import { test as base, expect } from "@playwright/test";
 import { Sidebar } from "./fixtures/sidebar";
 import { QgisResourcesPage } from "./fixtures/qgis-resources-page";
 import { InstallationGuidePage } from "./fixtures/installation-guide-page";
-import { ReleasesPage } from "./fixtures/releases-page";
 import { RoadmapPage } from "./fixtures/roadmap-page";
 import { ReportsPage } from "./fixtures/report-page";
 import { BooksPage } from "./fixtures/books-page";
@@ -11,7 +10,6 @@ type ResourcesPageFixtures = {
     sidebar: Sidebar;
     qgisResourcesPage: QgisResourcesPage;
     installationGuidePage: InstallationGuidePage;
-    releasesPage: ReleasesPage;
     roadmapPage: RoadmapPage;
     reportsPage: ReportsPage;
     booksPage: BooksPage;
@@ -29,10 +27,6 @@ const test = base.extend<ResourcesPageFixtures>({
     installationGuidePage: async ({ page }, use) => {
         const installationGuidePage = new InstallationGuidePage(page);
         await use(installationGuidePage);
-    },
-    releasesPage: async ({ page }, use) => {
-        const releasesPage = new ReleasesPage(page);
-        await use(releasesPage);
     },
     roadmapPage: async ({ page }, use) => {
         const roadmapPage = new RoadmapPage(page);
@@ -197,20 +191,6 @@ test.describe("Resources pages", () => {
         for (const text of installationGuidePage.textList) {
             await expect(installationGuidePage.pageBody).toContainText(text);
         }
-    });
-
-    test("Releases", async ({ page, sidebar, releasesPage }) => {
-        await expect(sidebar.releasesLink).toBeVisible();
-        await sidebar.releasesLink.click();
-
-        for (const text of releasesPage.textList) {
-            await expect(releasesPage.pageBody).toContainText(text);
-        }
-        await expect(releasesPage.releaseHeading).toBeVisible();
-        await expect(releasesPage.downloadLink).toBeVisible();
-        await expect(releasesPage.macOsReleaseLink).toBeVisible();
-        await expect(releasesPage.osgeoDownloadLink).toBeVisible();
-        await expect(releasesPage.pluginsLink).toBeVisible();
     });
 
     test("Roadmap", async ({ sidebar, roadmapPage }) => {

--- a/playwright/ci-test/tests/08-archive-page.spec.ts
+++ b/playwright/ci-test/tests/08-archive-page.spec.ts
@@ -1,0 +1,40 @@
+import { test as base, expect } from "@playwright/test";
+import { Sidebar } from "./fixtures/sidebar";
+import { ArchivePage } from "./fixtures/archive-page";
+
+type ResourcesPageFixtures = {
+    sidebar: Sidebar;
+    archivePage: ArchivePage;
+};
+
+const test = base.extend<ResourcesPageFixtures>({
+    sidebar: async ({ page }, use) => {
+        const sidebar = new Sidebar(page);
+        await use(sidebar);
+    },
+    archivePage: async ({ page }, use) => {
+        const archivePage = new ArchivePage(page);
+        await use(archivePage);
+    },
+});
+
+test.describe("Archive pages", () => {
+    test.beforeEach(async ({ archivePage }) => {
+        // Go to the resources url before each test.
+        await archivePage.goto();
+    });
+
+    test("Archive", async ({ page, sidebar, archivePage }) => {
+        await expect(sidebar.archiveLink).toBeVisible();
+        await sidebar.archiveLink.click();
+
+        for (const text of archivePage.textList) {
+            await expect(archivePage.pageBody).toContainText(text);
+        }
+        await expect(archivePage.archiveHeading).toBeVisible();
+        await expect(archivePage.downloadLink).toBeVisible();
+        await expect(archivePage.macOsReleaseLink).toBeVisible();
+        await expect(archivePage.osgeoDownloadLink).toBeVisible();
+        await expect(archivePage.pluginsLink).toBeVisible();
+    });
+});

--- a/playwright/ci-test/tests/fixtures/archive-page.ts
+++ b/playwright/ci-test/tests/fixtures/archive-page.ts
@@ -1,22 +1,26 @@
 import type { Page, Locator } from "@playwright/test";
 
-export class ReleasesPage {
+export class ArchivePage {
+    private readonly url: string = "/archive/";
     public readonly pageBody: Locator;
     public readonly textList: string[] = [
-        "Release Archive"
+        "Archive"
     ];
-    public readonly listOfReleases: Locator;
-    public readonly releaseHeading: Locator;
+    public readonly listOfArchive: Locator;
+    public readonly archiveHeading: Locator;
     public readonly downloadLink: Locator;
     public readonly macOsReleaseLink: Locator;
     public readonly osgeoDownloadLink: Locator;
     public readonly pluginsLink: Locator;
     constructor(public readonly page: Page) {
         this.pageBody = this.page.locator("body");
-        this.releaseHeading = this.page.getByRole('heading', { name: 'Release Archive' });
+        this.archiveHeading = this.page.getByRole('heading', { name: 'Archive' });
         this.downloadLink = this.page.getByRole('link', { name: 'QGIS.org hosted downloads' });
         this.macOsReleaseLink = this.page.getByRole('link', { name: 'Older releases for macOS / OS' });
         this.osgeoDownloadLink = this.page.getByRole('link', { name: 'OSGeo hosted downloads' });
         this.pluginsLink = this.page.getByRole('link', { name: 'at plugins.qgis.org' });
+    }
+    async goto() {
+        await this.page.goto(this.url);
     }
 }

--- a/playwright/ci-test/tests/fixtures/footer.ts
+++ b/playwright/ci-test/tests/fixtures/footer.ts
@@ -20,7 +20,7 @@ export class Footer {
     public readonly membersBlogsList: Locator;
     public readonly documentationLink: Locator;
     public readonly installationGuideLink: Locator;
-    public readonly releasesLink: Locator;
+    public readonly archiveLink: Locator;
     public readonly roadmapLink: Locator;
     public readonly reportsLink: Locator;
     public readonly booksLink: Locator;
@@ -86,7 +86,6 @@ export class Footer {
         this.installationGuideLink = this.liElement.filter({
             hasText: "Installation guide",
         });
-        this.releasesLink = this.banner.getByRole("link", { name: "Releases" });
         this.roadmapLink = this.banner.getByRole("link", { name: "Roadmap" });
         this.reportsLink = this.banner.getByRole("link", { name: "Reports" });
         this.booksLink = this.banner.getByRole("link", { name: "Books" });
@@ -111,6 +110,7 @@ export class Footer {
             name: "Visual Style Guide",
         });
         this.goodiesLink = this.page.getByRole("link", { name: "Goodies" });
+        this.archiveLink = this.page.getByRole("link", { name: "Archive" });
         this.logoImage = this.page.getByRole("img", { name: "Logo" });
         this.facebookLink = this.page.getByRole("link", { name: "" });
         this.youtubeLink = this.page.getByRole("link", { name: "" });

--- a/playwright/ci-test/tests/fixtures/sidebar.ts
+++ b/playwright/ci-test/tests/fixtures/sidebar.ts
@@ -19,7 +19,7 @@ export class Sidebar {
     public readonly documentationLink: Locator;
     public readonly membershipLink: Locator;
     public readonly installationGuideLink: Locator;
-    public readonly releasesLink: Locator;
+    public readonly archiveLink: Locator;
     public readonly roadmapLink: Locator;
     public readonly reportsLink: Locator;
     public readonly booksLink: Locator;
@@ -85,8 +85,8 @@ export class Sidebar {
             name: "Installation guide",
         });
 
-        this.releasesLink = this.sidebar.getByRole("link", {
-            name: "Releases",
+        this.archiveLink = this.sidebar.getByRole("link", {
+            name: "Archive",
             exact: true,
         });
 

--- a/themes/hugo-bulma-blocks-theme/layouts/partials/footer.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/partials/footer.html
@@ -119,6 +119,7 @@
             <a href="{{ absURL "license" }}" class="column is-narrow">License</a>
             <a href="{{ absURL "styleguide" }}" class="column is-narrow">Visual Style Guide</a>   
             <a href="{{ absURL "goodies" }}" class="column is-narrow">Goodies</a>   
+            <a href="{{ absURL "archive" }}" class="column is-narrow">Archive</a>   
 
         </div>
         <div class="columns is-desktop issue-report-link is-justify-content-center">


### PR DESCRIPTION
This is the proposed fix for #319 
Please note that the current PR depends on https://github.com/qgis/qgis-uni-navigation/pull/8 which updates the navigation bar menu.

![image](https://github.com/user-attachments/assets/a268870a-a703-447d-99bd-225575852e1e)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added "Archive" menu item to the main menu and footer for easier access to past versions.

- **Improvements**
  - Renamed "Releases" page to "Archive" to better reflect its purpose.
  
- **Testing**
  - Updated tests to verify the presence and functionality of the new "Archive" page link.
  - Removed tests related to the discontinued "Releases" page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->