### PR TITLE
Go to the top when clicking on skip and go to download

### DIFF
--- a/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-platforms-end.html
+++ b/themes/hugo-bulma-blocks-theme/layouts/shortcodes/download-platforms-end.html
@@ -7,6 +7,7 @@ function hidePrompt() {
     // uncomment next line to show donate-prompt only for the first time
     // localStorage.setItem('donatePromptClosed', true);
     document.getElementById('download-section').style.display = 'block';
+    window.scrollTo(0, 0);
 }
 
 function detectOS() {


### PR DESCRIPTION
This is the proposed fix for #325 

https://github.com/user-attachments/assets/2286c463-1ea9-4b56-ad6a-5c6c76a3c2d0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented auto-scrolling to the top of the page when the download section is displayed for a more streamlined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->