### PR TITLE
Add deploy and revert commands into the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,20 @@ build: ## Build the site for nocache.qgis.org, www.qgis.org and qgis.org
 	hugo --config config.toml,config/config.www.toml
 
 
+deploy: ## Deploy the site for nocache.qgis.org, www.qgis.org and qgis.org
+	@echo
+	@echo "------------------------------------------------------------------"
+	@echo "Deploy site in production"
+	@echo "------------------------------------------------------------------"
+	git pull && rm -rf archive; mkdir archive; mv public_www public_prod public_nocache archive; make build
+
+revert-deploy: ## Revert the site for nocache.qgis.org, www.qgis.org and qgis.org
+	@echo
+	@echo "------------------------------------------------------------------"
+	@echo "Deploy site in production"
+	@echo "------------------------------------------------------------------"
+	rm -rf public_www public_prod public_nocache; cp -r archive/public_www archive/public_prod archive/public_nocache ./
+
 # ----------------------------------------------------------------------------
 #    D E V E L O P M E N T     C O M M A N D S
 # ----------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ deploy: ## Deploy the site for nocache.qgis.org, www.qgis.org and qgis.org
 revert-deploy: ## Revert the site for nocache.qgis.org, www.qgis.org and qgis.org
 	@echo
 	@echo "------------------------------------------------------------------"
-	@echo "Deploy site in production"
+	@echo "Revert to the previous state in production"
 	@echo "------------------------------------------------------------------"
 	rm -rf public_www public_prod public_nocache; cp -r archive/public_www archive/public_prod archive/public_nocache ./
 


### PR DESCRIPTION
Proposed fix for #362 

- To back up current build files and deploy new changes: `make deploy`
- To revert the last build files: `make revert-deploy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `deploy` command for streamlined site deployment to production.
	- Added a `revert-deploy` command for easy rollback to previous site versions.
  
These enhancements provide better control and safety in managing the production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->